### PR TITLE
feature(zip blob): replace reserved characters with underscore

### DIFF
--- a/nuxeo-core/nuxeo-core-api/src/main/java/org/nuxeo/ecm/core/utils/BlobUtils.java
+++ b/nuxeo-core/nuxeo-core-api/src/main/java/org/nuxeo/ecm/core/utils/BlobUtils.java
@@ -46,6 +46,8 @@ public class BlobUtils {
 
     public static final String ZIP_ENTRY_ENCODING_PROPERTY = "zip.entry.encoding";
 
+    private static final String INVALID_CHARACTERS_REGEX = "[\\/:*?\"<>|]";
+
     protected static String escapeEntryPath(String path) {
         String zipEntryEncoding = Framework.getProperty(ZIP_ENTRY_ENCODING_PROPERTY);
         if (zipEntryEncoding != null && zipEntryEncoding.equals(ZIP_ENTRY_ENCODING_OPTIONS.ascii.toString())) {
@@ -129,6 +131,7 @@ public class BlobUtils {
             if (!names.add(entry)) {
                 entry = "renamed_" + (cnt++) + "_" + entry;
             }
+            entry = entry.replaceAll(INVALID_CHARACTERS_REGEX, "_");
             InputStream in = blob.getStream();
             try {
                 ZipUtils._zip(entry, in, out);


### PR DESCRIPTION
If a zip file contains files, such that the filenames contains reserved characters, is extracted on Mac OS but not on Windows.

e.g. `/temp/file.pdf`, `test: order_123`, `test|order_123` etc.



> https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions
< (less than)
\> (greater than)
: (colon)
" (double quote)
/ (forward slash)
\ (backslash)
| (vertical bar or pipe)
? (question mark)
\* (asterisk)